### PR TITLE
Add VirtualBrain discovery, refactor Brain orchestration, add workflows and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,65 @@
 # Aisistem
-A.I, assistant for everyone
+
+A.I assistant for everyone.
+
+## Virtual brain
+
+Run the assistant:
+
+```bash
+python -m main
+```
+
+The brain runs a cognitive loop inspired by real brain flow:
+
+- **Perception**: listen for input and normalize text.
+- **Comprehension**: analyze language signals (length, words, and top terms).
+- **Reasoning**: generate a response from `think`.
+- **Memory**: store cycle history in memory.
+- **Action**: speak the result and archive when archive utilities exist.
+
+## Autonomous mode
+
+Run autonomous thinking cycles (no user input):
+
+```bash
+python -c "import autonom; autonom.run_auto(3)"
+```
+
+In autonomous mode, the assistant produces internal prompts based on prior
+memory, so each cycle reflects on previous outputs.
+
+## n8n-style workflow mode
+
+You can run graph workflows where each node calls a module function and passes
+its output to the next node.
+
+```python
+from brains import Brain
+
+workflow = {
+    "start": "normalize",
+    "nodes": {
+        "normalize": {
+            "module": "understand",
+            "function": "normalize",
+            "input": "payload",
+            "output": "normalized",
+            "next": "respond",
+        },
+        "respond": {
+            "module": "think",
+            "function": "generate_response",
+            "input": "normalized",
+            "output": "response",
+            "next": None,
+        },
+    },
+}
+
+result = Brain().run_workflow(workflow, "HELLO")
+print(result["response"])
+```
+
+Condition nodes are also supported with `type="condition"` and branching via
+`true_next` / `false_next`.

--- a/autonom.py
+++ b/autonom.py
@@ -1,8 +1,10 @@
 """Automatic loop runner for the assistant."""
 
-import brains
+from brains import Brain
 
 
-def run_auto() -> None:
-    """Run the brain until interrupted."""
-    brains.run()
+def run_auto(cycles: int = 3) -> None:
+    """Run autonomous cognition cycles."""
+
+    brain = Brain()
+    brain.run_autonomous(cycles=cycles)

--- a/brains.py
+++ b/brains.py
@@ -1,24 +1,232 @@
-import listen
-import think
-import speak
+"""High level orchestration for a brain-like virtual assistant.
+
+Besides interactive and autonomous chat, this module now supports an n8n-style
+workflow runner where each node maps to a discovered module/function and passes
+context to the next node.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from Memory import MemoryManager
+from virtual_brain import VirtualBrain
+
+
+@dataclass
+class CognitiveState:
+    """Snapshot produced by one cognition cycle."""
+
+    raw_input: str
+    normalized_input: str
+    analysis: dict[str, Any]
+    response: str
+    timestamp: str
 
 
 class Brain:
-    """Simple orchestrator combining modules like a brain."""
+    """High level orchestrator combining discovered brain regions."""
 
-    def run(self):
+    def __init__(self) -> None:
+        self._virtual_brain = VirtualBrain()
+        self._memory = MemoryManager()
+
+        self._listen: Callable[..., str] = self._virtual_brain.get_function(
+            "listen", "get_input"
+        )
+        self._think: Callable[[str], str] = self._virtual_brain.get_function(
+            "think", "generate_response"
+        )
+        self._speak: Callable[[str], None] = self._virtual_brain.get_function("speak", "say")
+
+        self._normalize = self._load_optional("understand", "normalize")
+        self._word_frequencies = self._load_optional("analyze", "word_frequencies")
+        self._archive_entry = self._load_optional("archive", "archive_entry")
+
+    def _load_optional(self, module: str, function: str) -> Callable[..., Any] | None:
+        try:
+            return self._virtual_brain.get_function(module, function)
+        except (KeyError, AttributeError, ImportError):
+            return None
+
+    @property
+    def summary(self) -> str:
+        """Return a textual description of all loaded brain regions."""
+
+        return self._virtual_brain.summary()
+
+    def _timestamp(self) -> str:
+        return datetime.now(tz=timezone.utc).isoformat()
+
+    def _normalize_text(self, message: str) -> str:
+        if self._normalize is None:
+            return message.strip().lower()
+        return str(self._normalize(message)).strip()
+
+    def _analyze_text(self, message: str) -> dict[str, Any]:
+        if self._word_frequencies is None:
+            return {"length": len(message), "words": len(message.split())}
+        frequencies = self._word_frequencies(message)
+        top_terms = sorted(frequencies.items(), key=lambda item: item[1], reverse=True)[:3]
+        return {"length": len(message), "words": len(message.split()), "top_terms": top_terms}
+
+    def _store_state(self, state: CognitiveState) -> None:
+        history = self._memory.recall("history", [])
+        history.append(
+            {
+                "input": state.raw_input,
+                "normalized": state.normalized_input,
+                "analysis": state.analysis,
+                "response": state.response,
+                "timestamp": state.timestamp,
+            }
+        )
+        self._memory.store("history", history)
+        self._memory.store("last_response", state.response)
+
+    def process_message(self, message: str) -> CognitiveState:
+        """Run one complete cognition cycle and return the resulting state."""
+
+        normalized = self._normalize_text(message)
+        analysis = self._analyze_text(normalized)
+        try:
+            response = self._think(normalized)
+        except Exception as exc:  # pragma: no cover - resilience path
+            response = f"Internal reasoning fallback: {exc}"
+        state = CognitiveState(
+            raw_input=message,
+            normalized_input=normalized,
+            analysis=analysis,
+            response=response,
+            timestamp=self._timestamp(),
+        )
+        self._store_state(state)
+        if self._archive_entry is not None:
+            self._archive_entry(f"[{state.timestamp}] USER={message} BOT={response}")
+        return state
+
+    def _build_autonomous_prompt(self) -> str:
+        history = self._memory.recall("history", [])
+        regions_count = len(self._virtual_brain.regions())
+        if not history:
+            return (
+                "Autonomous boot thought: establish baseline awareness and state "
+                f"using {regions_count} regions."
+            )
+        last = history[-1]
+        return (
+            "Autonomous reflection: refine previous response "
+            f"'{last['response']}' using analysis {last['analysis']}."
+        )
+
+    def run_autonomous(self, cycles: int = 3) -> list[CognitiveState]:
+        """Run autonomous cognition cycles without user input."""
+
+        states: list[CognitiveState] = []
+        for _ in range(cycles):
+            prompt = self._build_autonomous_prompt()
+            state = self.process_message(prompt)
+            self._speak(state.response)
+            states.append(state)
+        return states
+
+    def run_workflow(self, workflow: dict[str, Any], payload: str) -> dict[str, Any]:
+        """Execute an n8n-like workflow graph.
+
+        Workflow shape::
+
+            {
+              "start": "node_id",
+              "nodes": {
+                "node_id": {
+                  "module": "understand",
+                  "function": "normalize",
+                  "input": "payload",
+                  "output": "normalized",
+                  "next": "another_node"
+                }
+              }
+            }
+
+        Supported nodes:
+        - function node: ``module`` + ``function`` (+ optional ``input``/``output``)
+        - condition node: ``type='condition'`` with ``key``, ``operator`` and ``value``
+          and branch targets ``true_next``/``false_next``
+        """
+
+        context: dict[str, Any] = {
+            "payload": payload,
+            "last_response": self._memory.recall("last_response"),
+            "history": self._memory.recall("history", []),
+        }
+        nodes = workflow.get("nodes", {})
+        current = workflow.get("start")
+        visited = 0
+
+        while current is not None:
+            if current not in nodes:
+                raise KeyError(f"Unknown workflow node: {current}")
+            visited += 1
+            if visited > 100:
+                raise RuntimeError("Workflow exceeded safe node limit (possible loop)")
+
+            node = nodes[current]
+            node_type = node.get("type", "function")
+            if node_type == "condition":
+                current = self._run_condition_node(node, context)
+                continue
+
+            module = node["module"]
+            function = node["function"]
+            func = self._virtual_brain.get_function(module, function)
+            input_key = node.get("input", "payload")
+            output_key = node.get("output", function)
+            value = context.get(input_key)
+            context[output_key] = func(value)
+            current = node.get("next")
+
+        if "response" in context:
+            self._memory.store("last_response", context["response"])
+        return context
+
+    def _run_condition_node(self, node: dict[str, Any], context: dict[str, Any]) -> str | None:
+        key = node["key"]
+        operator = node.get("operator", "equals")
+        expected = node.get("value")
+        actual = context.get(key)
+
+        if operator == "contains":
+            result = str(expected) in str(actual)
+        elif operator == "equals":
+            result = actual == expected
+        elif operator == "starts_with":
+            result = str(actual).startswith(str(expected))
+        else:
+            raise ValueError(f"Unsupported operator: {operator}")
+
+        return node.get("true_next") if result else node.get("false_next")
+
+    def run(self) -> None:
+        """Run interactive chat loop until user quits or input ends."""
+
+        print("Virtual brain initialised. Available regions:")
+        print(self.summary)
         while True:
-            message = listen.get_input()
+            try:
+                message = self._listen()
+            except EOFError:
+                break
             if message.lower() == "quit":
                 break
-            response = think.generate_response(message)
-            speak.say(response)
+            state = self.process_message(message)
+            self._speak(state.response)
 
 
-def run():
+def run() -> None:
     Brain().run()
 
 
 if __name__ == "__main__":
     run()
-

--- a/tests/test_virtual_brain.py
+++ b/tests/test_virtual_brain.py
@@ -1,0 +1,131 @@
+import importlib
+import sys
+import types
+from unittest import mock
+
+
+def test_virtual_brain_summary_lists_regions():
+    virtual_brain = importlib.import_module("virtual_brain").VirtualBrain()
+    summary = virtual_brain.summary()
+    assert "listen" in summary
+    assert "think" in summary
+
+
+def test_virtual_brain_get_function_with_stubbed_think():
+    fake_chat = types.ModuleType("chat")
+    fake_chat.chatbot_response = lambda message: "ok"
+    with mock.patch.dict(sys.modules, {"chat": fake_chat}):
+        think = importlib.reload(importlib.import_module("think"))
+        assert think.generate_response("hello") == "ok"
+
+
+def test_think_fallback_when_chat_import_fails():
+    with mock.patch.dict(sys.modules, {"chat": None}):
+        think = importlib.reload(importlib.import_module("think"))
+        response = think.generate_response("hello")
+        assert "hello" in response.lower()
+
+
+def test_brain_autonomous_cycles_store_memory():
+    fake_chat = types.ModuleType("chat")
+    fake_chat.chatbot_response = lambda message: f"answer:{message[:20]}"
+
+    outputs: list[str] = []
+
+    fake_speak = types.ModuleType("speak")
+    fake_speak.say = lambda message: outputs.append(message)
+
+    with mock.patch.dict(sys.modules, {"chat": fake_chat, "speak": fake_speak}):
+        brains = importlib.reload(importlib.import_module("brains"))
+        brain = brains.Brain()
+        states = brain.run_autonomous(cycles=2)
+
+    assert len(states) == 2
+    assert len(outputs) == 2
+    assert all(state.response.startswith("answer:") for state in states)
+
+
+def test_brain_n8n_style_workflow_runs_linear_nodes():
+    fake_chat = types.ModuleType("chat")
+    fake_chat.chatbot_response = lambda message: f"chat:{message}"
+
+    fake_speak = types.ModuleType("speak")
+    fake_speak.say = lambda message: message
+
+    with mock.patch.dict(sys.modules, {"chat": fake_chat, "speak": fake_speak}):
+        brains = importlib.reload(importlib.import_module("brains"))
+        brain = brains.Brain()
+
+        workflow = {
+            "start": "normalize",
+            "nodes": {
+                "normalize": {
+                    "module": "understand",
+                    "function": "normalize",
+                    "input": "payload",
+                    "output": "normalized",
+                    "next": "respond",
+                },
+                "respond": {
+                    "module": "think",
+                    "function": "generate_response",
+                    "input": "normalized",
+                    "output": "response",
+                    "next": None,
+                },
+            },
+        }
+        result = brain.run_workflow(workflow, "HELLO")
+
+    assert result["normalized"] == "hello"
+    assert result["response"] == "chat:hello"
+
+
+def test_brain_n8n_style_workflow_condition_branching():
+    fake_chat = types.ModuleType("chat")
+    fake_chat.chatbot_response = lambda message: f"chat:{message}"
+
+    fake_speak = types.ModuleType("speak")
+    fake_speak.say = lambda message: message
+
+    with mock.patch.dict(sys.modules, {"chat": fake_chat, "speak": fake_speak}):
+        brains = importlib.reload(importlib.import_module("brains"))
+        brain = brains.Brain()
+
+        workflow = {
+            "start": "normalize",
+            "nodes": {
+                "normalize": {
+                    "module": "understand",
+                    "function": "normalize",
+                    "input": "payload",
+                    "output": "normalized",
+                    "next": "gate",
+                },
+                "gate": {
+                    "type": "condition",
+                    "key": "normalized",
+                    "operator": "contains",
+                    "value": "hello",
+                    "true_next": "respond",
+                    "false_next": "fallback",
+                },
+                "respond": {
+                    "module": "think",
+                    "function": "generate_response",
+                    "input": "normalized",
+                    "output": "response",
+                    "next": None,
+                },
+                "fallback": {
+                    "module": "understand",
+                    "function": "normalize",
+                    "input": "payload",
+                    "output": "response",
+                    "next": None,
+                },
+            },
+        }
+        result = brain.run_workflow(workflow, "Hello n8n")
+
+    assert result["response"] == "chat:hello n8n"

--- a/think.py
+++ b/think.py
@@ -1,7 +1,29 @@
-from chat import chatbot_response
+"""Reasoning helpers for the assistant.
+
+The preferred backend is ``chat.chatbot_response``. When heavyweight runtime
+requirements are missing, this module falls back to a deterministic local
+response strategy so the rest of the brain can keep operating.
+"""
+
+from __future__ import annotations
+
+
+try:
+    from chat import chatbot_response as _chatbot_response
+except Exception:  # pragma: no cover - optional dependency path
+    _chatbot_response = None
+
+
+def _fallback_response(message: str) -> str:
+    cleaned = message.strip()
+    if not cleaned:
+        return "I need an input signal to think."
+    return f"Autonomous reflection: I understood '{cleaned}'."
 
 
 def generate_response(message: str) -> str:
-    """Generate a response using the chatbot model."""
-    return chatbot_response(message)
+    """Generate a response using the chatbot model or local fallback."""
 
+    if _chatbot_response is None:
+        return _fallback_response(message)
+    return _chatbot_response(message)

--- a/virtual_brain.py
+++ b/virtual_brain.py
@@ -1,0 +1,129 @@
+"""Virtual brain that discovers and orchestrates repository modules.
+
+The project contains many small modules that represent different cognitive
+abilities (``listen``, ``think``, ``analyze`` and so on).  This module stitches
+them together by scanning the repository, exposing light-weight metadata for
+each module and lazily importing them when required.  The design makes it easy
+to introspect the available building blocks without eagerly importing optional
+dependencies such as TensorFlow.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import ast
+import inspect
+import importlib
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Callable, Dict, Iterable
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+EXCLUDED_MODULES = {"virtual_brain", "main", "tests"}
+
+
+def _discover_python_files(directory: Path) -> Iterable[Path]:
+    """Yield Python files that belong to the virtual brain."""
+
+    for path in directory.glob("*.py"):
+        if path.stem.startswith("_"):
+            continue
+        yield path
+
+
+@dataclass
+class BrainRegion:
+    """Metadata holder for a module participating in the virtual brain."""
+
+    name: str
+    path: Path
+    description: str
+    _module: ModuleType | None = field(default=None, init=False, repr=False)
+
+    def _load(self) -> ModuleType:
+        if self._module is None:
+            self._module = importlib.import_module(self.name)
+        return self._module
+
+    def get_callable(self, attribute: str) -> Callable[..., Any]:
+        module = self._load()
+        obj = getattr(module, attribute)
+        if not callable(obj):  # pragma: no cover - defensive branch
+            raise TypeError(f"Attribute '{attribute}' on module '{self.name}' is not callable")
+        return obj
+
+    def available_callables(self) -> Dict[str, Callable[..., Any]]:
+        """Return public callables exposed by the module."""
+
+        module = self._load()
+        members: Dict[str, Callable[..., Any]] = {}
+        for attr, value in vars(module).items():
+            if attr.startswith("_"):
+                continue
+            if callable(value):
+                members[attr] = value
+        return members
+
+
+class VirtualBrain:
+    """Aggregate view of the assistant's capabilities."""
+
+    def __init__(self) -> None:
+        self._regions: Dict[str, BrainRegion] = {}
+        self._discover_regions()
+
+    def _discover_regions(self) -> None:
+        for path in _discover_python_files(PROJECT_ROOT):
+            if path.stem in EXCLUDED_MODULES:
+                continue
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except SyntaxError:  # pragma: no cover - defensive branch
+                continue
+            doc = ast.get_docstring(tree) or "No description available."
+            region = BrainRegion(name=path.stem, path=path, description=doc)
+            self._regions[path.stem] = region
+
+    def regions(self) -> Dict[str, BrainRegion]:
+        """Return the discovered regions."""
+
+        return dict(self._regions)
+
+    def summary(self) -> str:
+        """Return a human friendly summary of the virtual brain."""
+
+        lines = []
+        for name in sorted(self._regions):
+            region = self._regions[name]
+            first_line = region.description.splitlines()[0]
+            lines.append(f"- {name}: {first_line}")
+        return "\n".join(lines)
+
+    def get_function(self, module_name: str, function_name: str) -> Callable[..., Any]:
+        """Retrieve a callable from the specified region."""
+
+        region = self._regions.get(module_name)
+        if region is None:
+            raise KeyError(f"Unknown region '{module_name}'")
+        return region.get_callable(function_name)
+
+    def describe_region(self, module_name: str) -> str:
+        """Return an extended description for a single region."""
+
+        region = self._regions.get(module_name)
+        if region is None:
+            raise KeyError(f"Unknown region '{module_name}'")
+        description = inspect.cleandoc(region.description)
+        callables = ", ".join(sorted(region.available_callables()))
+        return f"{module_name}: {description} | callables: {callables}"
+
+    def call(self, module_name: str, function_name: str, *args: Any, **kwargs: Any) -> Any:
+        """Convenience helper for invoking a callable on a region."""
+
+        func = self.get_function(module_name, function_name)
+        return func(*args, **kwargs)
+
+
+__all__ = ["VirtualBrain", "BrainRegion"]
+


### PR DESCRIPTION
### Motivation

- Provide a single, introspectable mechanism to discover and lazily load repository modules so optional heavy deps are not imported eagerly.
- Improve the brain orchestration to support autonomous cycles and n8n-style workflows while centralising state and memory handling.
- Make reasoning resilient when the external `chat` backend is unavailable by providing a deterministic fallback.
- Make the project easier to understand and run via an expanded `README.md` and automated tests.

### Description

- Add `virtual_brain.py` which discovers local Python modules as `BrainRegion`s, exposes summaries, and provides lazy callable access via `get_function` and `call`.
- Refactor `brains.py` to a `Brain` class that uses `VirtualBrain` and `MemoryManager`, introduces `CognitiveState` dataclass, `process_message`, `run_autonomous`, and `run_workflow` (n8n-style) methods, and improves interactive loop robustness.
- Update `think.py` to prefer `chat.chatbot_response` but fall back to a local `_fallback_response` when the backend is unavailable.
- Change `autonom.py` to use the `Brain` API (`run_auto` -> `run_auto(cycles)` calls `brain.run_autonomous`) and expand the `README.md` with usage examples for interactive, autonomous and workflow modes.
- Add unit tests in `tests/test_virtual_brain.py` that cover region discovery, `think` fallback, autonomous cycles storing memory, and workflow execution with condition branching.

### Testing

- Added `tests/test_virtual_brain.py` covering `VirtualBrain` discovery, `think` fallback behavior, `Brain.run_autonomous`, and `Brain.run_workflow` branching.
- Ran the test suite with `pytest -q` against the modified code and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68d4ea86637883249d19022529b1639c)